### PR TITLE
Fixed the Kinesis Flipper module raising some errors

### DIFF
--- a/src/pymodaq_plugins_thorlabs/daq_move_plugins/daq_move_Kinesis_Flipper.py
+++ b/src/pymodaq_plugins_thorlabs/daq_move_plugins/daq_move_Kinesis_Flipper.py
@@ -145,8 +145,9 @@ class DAQ_Move_Kinesis_Flipper(DAQ_Move_base):
             else: #Master stage
                
                 self.Device.DeviceManagerCLI.BuildDeviceList()
-                serialnumbers=self.Device.DeviceManagerCLI.GetDeviceList(self.Flipper.FilterFlipper.DevicePrefix)
-                ser_bool=serialnumbers.Contains(self.settings.child(('serial_number')).value())
+                serialnumbers = self.Device.DeviceManagerCLI.GetDeviceList(self.Flipper.FilterFlipper.DevicePrefix)
+                #Check if the serial number in the parameters exists in the available devices
+                ser_bool = self.settings.child(('serial_number')).value() in serialnumbers
                 if ser_bool:
                     self.controller=self.Flipper.FilterFlipper.CreateFilterFlipper(self.settings.child(('serial_number')).value())
                     self.controller.Connect(self.settings.child(('serial_number')).value())
@@ -161,11 +162,10 @@ class DAQ_Move_Kinesis_Flipper(DAQ_Move_base):
             if not(self.controller.IsSettingsInitialized()):
                 raise(Exception("no Stage Connected"))
 
-            self.status.info=info
-            self.status.controller=self.controller
-            self.status.initialized=True
+            self.status.info = info
+            self.status.controller = self.controller
+            self.status.initialized = True
             return self.status
-
 
         except Exception as e:
             self.emit_status(ThreadCommand('Update_Status',[getLineInfo()+ str(e),'log']))
@@ -177,8 +177,8 @@ class DAQ_Move_Kinesis_Flipper(DAQ_Move_base):
         """
             close the current instance of Kinesis Flipper instrument.
         """
-        self.controller.StopPolling();
-        self.controller.Disconnect();
+        self.controller.StopPolling()
+        self.controller.Disconnect()
         self.controller.Dispose()
         self.controller=None
 
@@ -219,7 +219,7 @@ class DAQ_Move_Kinesis_Flipper(DAQ_Move_base):
             DAQ_Move_base.set_position_with_scaling
 
         """
-        pos = self.Check_position()
+        pos = self.check_position()
         if int(pos) == 1:
             position = 2
         else:


### PR DESCRIPTION
Version from main would raise multiple errors preventing initialisation in the `Kinesis_Flipper` module

```
2022-03-31 17:39:04,962 - pymodaq.pymodaq.daq_move_main.test - INFO -   File "c:\users\admin\documents\pymodaq_dev\pymodaq_plugins_thorlabs\src\pymodaq_plugins_thorlabs\daq_move_plugins\daq_move_Kinesis_Flipper.py", line 149, in ini_stage
    ser_bool=serialnumbers.Contains(self.settings.child(('serial_number')).value())
'list' object has no attribute 'Contains'
2022-03-31 17:39:04,963 - pymodaq.pymodaq.daq_move_main.test - INFO - Stage initialized: False info:   File "c:\users\admin\documents\pymodaq_dev\pymodaq_plugins_thorlabs\src\pymodaq_plugins_thorlabs\daq_move_plugins\daq_move_Kinesis_Flipper.py", line 149, in ini_stage
    ser_bool=serialnumbers.Contains(self.settings.child(('serial_number')).value())
'list' object has no attribute 'Contains'

```

```
2022-03-31 17:57:22,068 - pymodaq.pymodaq.daq_move_main.test.actuator - ERROR - 'DAQ_Move_Kinesis_Flipper' object has no attribute 'Check_position'
Traceback (most recent call last):
  File "c:\users\admin\documents\pymodaq_dev\pymodaq\src\pymodaq\daq_move\daq_move_main.py", line 942, in queue_command
    self.move_Abs(*command.attributes)
  File "c:\users\admin\documents\pymodaq_dev\pymodaq\src\pymodaq\daq_move\daq_move_main.py", line 842, in move_Abs
    pos = self.hardware.move_Abs(position)
  File "c:\users\admin\documents\pymodaq_dev\pymodaq_plugins_thorlabs\src\pymodaq_plugins_thorlabs\daq_move_plugins\daq_move_Kinesis_Flipper.py", line 222, in move_Abs
    pos = self.Check_position()
```

Both should be corrected with this version

Cheers

Nicolas